### PR TITLE
fix url file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ttl
 *.bzip2
+*.bz2
 *.zip
 
 # Created by https://www.toptal.com/developers/gitignore/api/node

--- a/src/downloadDump.sh
+++ b/src/downloadDump.sh
@@ -6,8 +6,8 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-URL="https://databus.dbpedia.org/dbpedia/text/short-abstracts/$2/short-abstracts_lang=$1.ttl.bz2"
-ARCHIVE="short-abstracts_lang=$1.ttl.bzip2"
+ARCHIVE="short-abstracts_lang=$1.ttl.bz2"
+URL="https://databus.dbpedia.org/dbpedia/text/short-abstracts/$2/$ARCHIVE"
 FILE="short-abstracts_lang=$1.ttl"
 
 # Download the archive if neither the file nor archive exists

--- a/src/downloadDump.sh
+++ b/src/downloadDump.sh
@@ -6,7 +6,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-URL="https://databus.dbpedia.org/dbpedia/text/short-abstracts/$2/short-abstracts_lang=$1.ttl.bzip2"
+URL="https://databus.dbpedia.org/dbpedia/text/short-abstracts/$2/short-abstracts_lang=$1.ttl.bz2"
 ARCHIVE="short-abstracts_lang=$1.ttl.bzip2"
 FILE="short-abstracts_lang=$1.ttl"
 


### PR DESCRIPTION
Doesn't work for me otherwise, seems the files on https://databus.dbpedia.org/dbpedia/text/short-abstracts/ end in `bz` instead of `bzip` now?